### PR TITLE
[WIP] enable async.each iterator to get index or key as 2nd argument

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -336,7 +336,9 @@
     var size;
     var completed = 0;
     var _iterator = thisArg ? iterator.bind(thisArg) : iterator;
-    var iterate = function(item) {
+    var iterate = _iterator.length === 3 ? function(item, keyOrIndex) {
+      _iterator(item, keyOrIndex, once(done));
+    } : function(item) {
       _iterator(item, once(done));
     };
 

--- a/test/collections/test.each.js
+++ b/test/collections/test.each.js
@@ -23,6 +23,25 @@ function eachIterator(order) {
   };
 }
 
+function eachIteratorWithKey(order) {
+
+  return function(num, key, callback) {
+
+    var self = this;
+
+    setTimeout(function() {
+
+      if (self && self.round) {
+        num = self.round(num);
+      }
+
+      order.push(num);
+      callback();
+
+    }, num * 10);
+  };
+}
+
 describe('#each', function() {
 
   it('should execute iterator by collection of array', function(done) {
@@ -57,6 +76,19 @@ describe('#each', function() {
 
   });
 
+  it('should execute iterator by collection of array with passing index', function(done) {
+
+    var order = [];
+    var collection = [1, 3, 2];
+    async.each(collection, eachIteratorWithKey(order), function(err) {
+      if (err) {
+        return done(err);
+      }
+      assert.deepEqual(order, [1, 2, 3]);
+      done();
+    });
+
+  });
   it('should execute iterator with binding', function(done) {
 
     var order = [];


### PR DESCRIPTION
usage:

`async.each(arr, function(item, index, done) { /* ... */ }, callback);`
or
`async.each(obj, function(item, key, done) { /* ... */ }, callback);`

I only implemented it to async.each, so it should not be merged yet. I just want to hear your opinion.
Thank you.