### PR TITLE
ci: test Node.js 6, 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ language: node_js
 
 after_success: 'make test-codecov; make clean'
 
+install: npm install
+
 node_js:
+  - 'node'
   - '10'
   - '8'
   - '6'
-  - '4'


### PR DESCRIPTION
Node.js 6, 8 and 10 are current LTS branches and 11 is stable.

See https://github.com/nodejs/Release/blob/master/README.md

Node.js 4 already reached its EOL.