### PR TITLE
perf(queue): Use shift instead of splice (when possible) in queue

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -8067,7 +8067,7 @@
             if (workersList[index] === task) {
               if (index === 0) {
                 workersList.shift();
-              } else if (index > 0) {
+              } else {
                 workersList.splice(index, 1);
               }
               index = size;


### PR DESCRIPTION
Hi, maybe you need this change, which has used in `async.queue`.[https://github.com/caolan/async/pull/1454](https://github.com/caolan/async/pull/1454)