### PR TITLE
replace unshift with reverseArray

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -7824,6 +7824,7 @@
 
       function done(err, res) {
         res = isArray(res) ? res : [res];
+        res=(res instanceof ReverseArray)? res: ReverseArray(res);
         res.unshift(err);
         callback.apply(self, res);
       }
@@ -7854,6 +7855,46 @@
   /**
    * @see https://github.com/caolan/async/blob/master/lib/internal/DoublyLinkedList.js
    */
+
+  /**
+   * creates an array the enables to shift in O(1) and read in O(1).
+   * of course now pushing is O(n)
+   * @param arr- an array that will form the base of the structure. It is not cloned!
+   * @returns {ReverseArray}- An array like data-structure
+   * which its complexity is opposite to normal regarding adding and removing elements
+   * @constructor
+   * @private
+   */
+  var ReverseArray=function(arr)
+  {
+    return new Proxy(arr,{
+      get:function(target, p) {
+        if(!isNaN(p)) //is a number in a string?
+          {
+            let lastEelement = target.length-1;
+            return target[lastEelement-p];
+          }
+        else if(p==="unshift")
+          return target.push;
+          else if(p==="shift")
+            return target.pop;
+        else if(p==="pop")
+          return target.shift;
+          else if(p==="top")
+        {
+          let lastEelement = target.length-1;
+          return target[lastEelement];
+        }
+          else if(p==="push") {
+          return target.unshift;
+        }
+        else
+        {
+          return target[p];
+        }
+      }
+    });
+  }
   function DLL() {
     this.head = null;
     this.tail = null;

--- a/lib/async.js
+++ b/lib/async.js
@@ -1939,6 +1939,45 @@
    * });
    *
    */
+  /**
+   * @see https://github.com/caolan/async/blob/master/lib/internal/DoublyLinkedList.js
+   */
+
+  /**
+   * creates an array the enables to shift in O(1) and read in O(1).
+   * of course now pushing is O(n)
+   * @param arr- an array that will form the base of the structure. It is not cloned!
+   * @returns {ReverseArray}- An array like data-structure
+   * which its complexity is opposite to normal regarding adding and removing elements
+   * @constructor
+   * @private
+   */
+  var ReverseArray=function(arr)
+  {
+    return new Proxy(arr,{
+      get:function(target, p) {
+        if(!isNaN(p)) //is a number in a string?
+        {
+          let lastEelement = target.length-1;
+          return target[lastEelement-p];
+        }
+        else if(p==="unshift")
+          return target.push;
+        else if(p==="shift")
+          return target.pop;
+        else if(p==="pop")
+          return target.shift;
+
+        else if(p==="push") {
+          return target.unshift;
+        }
+        else
+        {
+          return target[p];
+        }
+      }
+    });
+  }
   var parallel = createParallel(arrayEachFunc, baseEachFunc);
 
   /**
@@ -2090,7 +2129,7 @@
     reflectAll: reflectAll,
     timeout: timeout,
     createLogger: createLogger,
-
+    ReverseArray:ReverseArray,
     // Mode
     safe: safe,
     fast: fast
@@ -7852,49 +7891,7 @@
     };
   }
 
-  /**
-   * @see https://github.com/caolan/async/blob/master/lib/internal/DoublyLinkedList.js
-   */
 
-  /**
-   * creates an array the enables to shift in O(1) and read in O(1).
-   * of course now pushing is O(n)
-   * @param arr- an array that will form the base of the structure. It is not cloned!
-   * @returns {ReverseArray}- An array like data-structure
-   * which its complexity is opposite to normal regarding adding and removing elements
-   * @constructor
-   * @private
-   */
-  var ReverseArray=function(arr)
-  {
-    return new Proxy(arr,{
-      get:function(target, p) {
-        if(!isNaN(p)) //is a number in a string?
-          {
-            let lastEelement = target.length-1;
-            return target[lastEelement-p];
-          }
-        else if(p==="unshift")
-          return target.push;
-          else if(p==="shift")
-            return target.pop;
-        else if(p==="pop")
-          return target.shift;
-          else if(p==="top")
-        {
-          let lastEelement = target.length-1;
-          return target[lastEelement];
-        }
-          else if(p==="push") {
-          return target.unshift;
-        }
-        else
-        {
-          return target[p];
-        }
-      }
-    });
-  }
   function DLL() {
     this.head = null;
     this.tail = null;

--- a/lib/async.js
+++ b/lib/async.js
@@ -8240,7 +8240,7 @@
       return callback(null, results);
     }
     var runningTasks = 0;
-    var readyTasks = [];
+    var readyTasks = new DLL();
     var listeners = Object.create(null);
     callback = onlyOnce(callback || noop);
     concurrency = concurrency || rest;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "neo-async",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neo-async",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Neo-Async is a drop-in replacement for Async, it almost fully covers its functionality and runs faster ",
   "main": "lib/async.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
     "cov:100": "grep Lines | perl -nle 'my ($l, $c, $p, @d) = split(/[\\s%]+/); exit(($p == 100) == 0)'"
   },
   "license": "MIT",
-  "keywords": ["async", "util"],
+  "keywords": [
+    "async",
+    "util"
+  ],
   "private": true,
   "repository": {
     "type": "git",

--- a/test/utils/test.reverseArray.js
+++ b/test/utils/test.reverseArray.js
@@ -1,0 +1,65 @@
+/* global it, describe */
+'use strict';
+
+var assert = require('assert');
+
+var async = require('../../');
+var delay = require('../config').delay;
+var util = require('../util');
+describe('#ReverseArray', function() {
+
+
+
+  it('should be exact opposite to each other', function(done) {
+    let arr=Array.from({length: 100}, () => Math.floor(Math.random() * 100));
+    let rarr=async.ReverseArray(arr);
+
+    for(let i=0;i<arr.length;i++)
+    {
+        assert.equal(arr[i],rarr[rarr.length-1-i]);
+    }
+    done();
+
+
+  });
+
+  it("should unshift",function(done)
+    {
+      let rarr=async.ReverseArray([]);
+      for(let i=100;i>=0;i--)
+        rarr.unshift(i);
+      for(let i=0;i<=100;i++)
+        assert.equal(i,rarr[i]);
+      done();
+
+    }
+  );
+
+  it("should shift",function(done) {
+    let arr=Array.from({length:100});
+    let rarr=async.ReverseArray(arr);
+    for(let i=0;i<100;i++)
+      rarr.shift();
+    assert.equal(rarr.length,0)
+    done();
+  });
+
+  it("should pop, slowly",function(done) {
+    let arr=Array.from({length:100}); // on this data-structure pop is the expensive side!!!!
+    let rarr=async.ReverseArray(arr);
+    for(let i=0;i<100;i++)
+      rarr.pop();
+    assert.equal(rarr.length,0)
+    done();
+  });
+
+  it("pop",function(done) {
+    let arr=Array.from({length: 100}, () => Math.floor(Math.random() * 100));
+    let rarr=async.ReverseArray(arr);
+
+    const someNumber = 1113;
+    rarr.push(someNumber);
+    assert.equal(rarr[rarr.length-1],someNumber)
+    done();
+  });
+});


### PR DESCRIPTION
This pull request solves #74's first example by introducing a new data-structure to the package. the reversed array. It switches unshift by push operation. Effectively, decreases complexity from O(n) to O(1).

Of course we do need to benchmark the proxy creation cost, but it should be O(1) too.