### PR TITLE
fix memory leak in queue

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -8024,6 +8024,8 @@
       _unshift = unshift;
       _callback = callback;
       arrayEachSync(_tasks, _exec);
+      // Avoid leaking the callback
+      _callback = undefined;
     }
 
     function kill() {


### PR DESCRIPTION
The queue used to keep a reference to the last inserted callback function with the queue object.
This causes the queue to hold onto a lot more memory than it need to.