### PR TITLE
updated lodash from 4.17.19 to 4.17.21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4208,9 +4208,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "lodash._baseassign": {
@@ -6573,7 +6573,8 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
       "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "strip-ansi": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "jsdoc": "^3.5.5",
     "jshint": "^2.9.5",
     "lint-staged": "^10.2.11",
-    "lodash": "^4.17.19",
+    "lodash": "^4.17.21",
     "minimist": "^1.2.3",
     "mocha": "^3.5.3",
     "mocha-parallel-executor": "^0.3.0",


### PR DESCRIPTION
Hi! 👋
This PR updates the version of lodash to fix https://github.com/advisories/GHSA-p6mc-m468-83gw.
The tests seem to pass, let me know if you need anything else!